### PR TITLE
feat: add 3D flipbook website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # FQCalendarWeb
+
+静态 3D 电子画册示例。将图片按 `1.jpg`, `2.jpg` … 命名后放入 `content/` 目录中，然后在浏览器中打开 `index.html` 体验翻页效果。

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,187 @@
+/* 基础布局 */
+html,body{
+  margin:0;
+  padding:0;
+  height:100%;
+  background:#f0f0f0;
+  font-family:Arial, Helvetica, sans-serif;
+}
+
+.bookContainer{
+  position:relative;
+  margin:40px auto;
+  perspective:2000px;
+}
+
+.book{
+  position:relative;
+  transform-style:preserve-3d;
+}
+
+.page{
+  position:absolute;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  transform-origin:left center;
+  transform-style:preserve-3d;
+  transition:transform 0.8s ease;
+}
+
+.page img{
+  width:100%;
+  height:100%;
+  display:block;
+  backface-visibility:hidden;
+}
+
+.page .back{
+  position:absolute;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  background:#fff;
+  backface-visibility:hidden;
+  transform:rotateY(180deg);
+}
+
+.page.flipped{
+  transform:rotateY(-180deg);
+}
+.page.vertical{
+  transform-origin:center top;
+}
+.page.vertical.flipped{
+  transform:rotateX(-180deg);
+}
+
+.mask{
+  position:absolute;
+  top:0;
+  left:0;
+  right:0;
+  bottom:0;
+  z-index:5;
+}
+
+/* 翻页细节 */
+.flip-side{backface-visibility:hidden;}
+.flip-hard-left-side{transform-origin:left center;}
+.flip-hard-right-side{transform-origin:right center;}
+.thickness{
+  position:absolute;
+  top:0;
+  bottom:0;
+  width:5px;
+  right:-5px;
+  background:linear-gradient(to right,#ccc,#eee,#ccc);
+}
+.shadow{
+  position:absolute;
+  top:0;left:0;right:0;bottom:0;
+  box-shadow:0 0 20px rgba(0,0,0,0.3);
+  pointer-events:none;
+}
+
+/* 工具栏 */
+.catalog_simple_bar{
+  position:fixed;
+  top:0;
+  left:0;
+  right:0;
+  height:40px;
+  background:rgba(255,255,255,0.9);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:20px;
+  z-index:10;
+}
+
+.loadingOuter{
+  position:fixed;
+  top:0;left:0;right:0;bottom:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:rgba(255,255,255,0.8);
+  z-index:100;
+}
+.loadingOuter .spinner{
+  width:60px;height:60px;
+  border-radius:50%;
+  border:6px solid #ccc;
+  border-top-color:#555;
+  animation:rotate 1s linear infinite;
+}
+
+.shareBar{
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  height:40px;
+  background:rgba(255,255,255,0.9);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:20px;
+}
+.shareBar .share{
+  text-decoration:none;
+  color:#555;
+}
+
+/* 悬浮工具栏 */
+.toolbox{
+  position:fixed;
+  top:50%;
+  right:20px;
+  transform:translateY(-50%);
+  z-index:20;
+}
+.toolbox .toggle{
+  width:40px;height:40px;
+  background:#333;
+  color:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  border-radius:4px;
+  animation:bounce 2s infinite;
+}
+.toolbox .tools{
+  display:none;
+  flex-direction:column;
+  margin-top:10px;
+}
+.toolbox.open .tools{display:flex;}
+.toolbox .tools button{
+  margin-bottom:5px;
+  padding:6px 10px;
+  cursor:pointer;
+}
+
+/* 角翻效果 */
+.bookContainer.hover-right .page.top{
+  transform:rotateY(-15deg);
+}
+.bookContainer.hover-left .page.top{
+  transform-origin:right center;
+  transform:rotateY(15deg);
+}
+.bookContainer.hover-top .page.top{
+  transform-origin:center top;
+  transform:rotateX(15deg);
+}
+.bookContainer.hover-bottom .page.top{
+  transform-origin:center bottom;
+  transform:rotateX(-15deg);
+}
+
+/* 动画 */
+@keyframes rotate{from{transform:rotate(0);}to{transform:rotate(360deg);}}
+@keyframes bounce{0%,100%{transform:translateY(0);}50%{transform:translateY(-10px);}}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D 电子画册</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div class="loadingOuter" id="loading">
+    <div class="spinner"></div>
+  </div>
+
+  <div class="catalog_simple_bar">
+    <button id="prevBtn">上一页</button>
+    <span id="pageIndicator">0 / 0</span>
+    <button id="nextBtn">下一页</button>
+  </div>
+
+  <div class="bookContainer">
+    <div class="shadow"></div>
+    <div class="thickness"></div>
+    <div class="book" id="book"></div>
+    <div class="mask" id="mask"></div>
+  </div>
+
+  <div class="shareBar">
+    <a href="#" class="share wechat">微信</a>
+    <a href="#" class="share weibo">微博</a>
+    <a href="#" class="share qzone">QQ空间</a>
+  </div>
+
+  <div class="toolbox" id="toolbox">
+    <div class="toggle" id="toolboxToggle">≡</div>
+    <div class="tools">
+      <button id="thumbsBtn">缩略图</button>
+      <button id="catalogBtn">目录</button>
+      <button id="autoBtn">自动翻页</button>
+      <button id="fullscreenBtn">全屏</button>
+    </div>
+  </div>
+
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,185 @@
+const book = document.getElementById('book');
+const bookContainer = document.querySelector('.bookContainer');
+const mask = document.getElementById('mask');
+const loading = document.getElementById('loading');
+const pageIndicator = document.getElementById('pageIndicator');
+const prevBtn = document.getElementById('prevBtn');
+const nextBtn = document.getElementById('nextBtn');
+
+let pages = [];
+let currentPage = 0;
+let autoFlipTimer = null;
+
+async function init(){
+  const imgs = await loadImages();
+  if(imgs.length === 0){
+    loading.style.display = 'none';
+    return;
+  }
+  const w = imgs[0].naturalWidth;
+  const h = imgs[0].naturalHeight;
+  bookContainer.style.width = w + 'px';
+  bookContainer.style.height = h + 'px';
+
+  imgs.forEach((img, i) => {
+    const page = document.createElement('div');
+    page.className = 'page flip-side' + (i === 0 ? ' top' : '');
+    page.style.zIndex = imgs.length - i;
+    page.appendChild(img);
+    const back = document.createElement('div');
+    back.className = 'back';
+    page.appendChild(back);
+    book.appendChild(page);
+    pages.push(page);
+  });
+  updateIndicator();
+  loading.style.display = 'none';
+}
+
+function loadImages(){
+  return new Promise(async (resolve) => {
+    const imgs = [];
+    let index = 1;
+    while(true){
+      try{
+        const img = await loadImage(`content/${index}.jpg`);
+        imgs.push(img);
+        index++;
+      }catch(e){
+        break;
+      }
+    }
+    resolve(imgs);
+  });
+}
+
+function loadImage(src){
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+function flipNext(){
+  if(currentPage >= pages.length - 1) return;
+  const page = pages[currentPage];
+  page.classList.remove('vertical');
+  page.classList.add('flipped');
+  currentPage++;
+  updateIndicator();
+}
+
+function flipPrev(){
+  if(currentPage <= 0) return;
+  currentPage--;
+  const page = pages[currentPage];
+  page.classList.remove('flipped');
+  setTimeout(() => page.classList.remove('vertical'), 800);
+  updateIndicator();
+}
+
+function flipUp(){
+  if(currentPage >= pages.length - 1) return;
+  const page = pages[currentPage];
+  page.classList.add('vertical');
+  page.classList.add('flipped');
+  currentPage++;
+  updateIndicator();
+}
+
+function flipDown(){
+  if(currentPage <= 0) return;
+  currentPage--;
+  const page = pages[currentPage];
+  page.classList.add('vertical');
+  page.classList.remove('flipped');
+  setTimeout(() => page.classList.remove('vertical'), 800);
+  updateIndicator();
+}
+
+function updateIndicator(){
+  pageIndicator.textContent = `${currentPage + 1} / ${pages.length}`;
+}
+
+prevBtn.addEventListener('click', flipPrev);
+nextBtn.addEventListener('click', flipNext);
+
+mask.addEventListener('mousemove', (e) => {
+  const rect = bookContainer.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const margin = 80;
+  if(x > rect.width - margin){
+    bookContainer.classList.add('hover-right');
+    bookContainer.classList.remove('hover-left','hover-top','hover-bottom');
+  }else if(x < margin){
+    bookContainer.classList.add('hover-left');
+    bookContainer.classList.remove('hover-right','hover-top','hover-bottom');
+  }else if(y < margin){
+    bookContainer.classList.add('hover-top');
+    bookContainer.classList.remove('hover-left','hover-right','hover-bottom');
+  }else if(y > rect.height - margin){
+    bookContainer.classList.add('hover-bottom');
+    bookContainer.classList.remove('hover-left','hover-right','hover-top');
+  }else{
+    bookContainer.classList.remove('hover-left','hover-right','hover-top','hover-bottom');
+  }
+});
+
+mask.addEventListener('mouseleave', () => {
+  bookContainer.classList.remove('hover-left','hover-right','hover-top','hover-bottom');
+});
+
+mask.addEventListener('click', (e) => {
+  const rect = bookContainer.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const margin = 80;
+  if(x > rect.width - margin){
+    flipNext();
+  }else if(x < margin){
+    flipPrev();
+  }else if(y < margin){
+    flipUp();
+  }else if(y > rect.height - margin){
+    flipDown();
+  }
+});
+
+// 悬浮工具栏
+const toolbox = document.getElementById('toolbox');
+document.getElementById('toolboxToggle').addEventListener('click', () => {
+  toolbox.classList.toggle('open');
+});
+
+const autoBtn = document.getElementById('autoBtn');
+autoBtn.addEventListener('click', () => {
+  if(autoFlipTimer){
+    clearInterval(autoFlipTimer);
+    autoFlipTimer = null;
+    autoBtn.classList.remove('active');
+  }else{
+    autoFlipTimer = setInterval(() => {
+      if(currentPage >= pages.length - 1){
+        clearInterval(autoFlipTimer);
+        autoFlipTimer = null;
+        autoBtn.classList.remove('active');
+        return;
+      }
+      flipNext();
+    }, 2000);
+    autoBtn.classList.add('active');
+  }
+});
+
+document.getElementById('fullscreenBtn').addEventListener('click', () => {
+  if(!document.fullscreenElement){
+    document.documentElement.requestFullscreen();
+  }else{
+    document.exitFullscreen();
+  }
+});
+
+window.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- add 3D flipbook layout and toolbar
- load sequential images from `content/` and support horizontal/vertical page turns
- include floating toolbox with auto-flip and fullscreen

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2007c9124832eb069f557fe6bfab7