### PR TITLE
Use composite for PSD export

### DIFF
--- a/tool/psd_to_png.py
+++ b/tool/psd_to_png.py
@@ -20,7 +20,10 @@ def psd_to_png(input_dir: str, output_dir: str | None = None) -> None:
 
     for psd_path in src.glob("*.psd"):
         psd = PSDImage.open(psd_path)
-        image = psd.compose()
+        # ``PSDImage.compose`` was renamed to ``PSDImage.composite`` in
+        # psd-tools 1.9.0.  The older name no longer exists in recent
+        # versions, so use ``composite`` to build the flattened image.
+        image = psd.composite()
         out_path = dst / f"{psd_path.stem}.png"
         image.save(out_path)
         print(f"Saved {out_path}")


### PR DESCRIPTION
## Summary
- switch from `PSDImage.compose` to `PSDImage.composite` when flattening PSDs
- explain rename in comments

## Testing
- `pip install psd-tools` *(fails: Could not find a version that satisfies the requirement psd-tools)*
- `python tool/psd_to_png.py -h` *(fails: ModuleNotFoundError: No module named 'psd_tools')*

------
https://chatgpt.com/codex/tasks/task_e_68a205ecd16c832ea9cf2eb3bf372d73