### PR TITLE
fix: display page images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,10 +30,14 @@ html,body{
 }
 
 .page img{
+  position:absolute;
+  top:0;
+  left:0;
   width:100%;
   height:100%;
   display:block;
   backface-visibility:hidden;
+  z-index:1;
 }
 
 .page .back{
@@ -45,6 +49,7 @@ html,body{
   background:#fff;
   backface-visibility:hidden;
   transform:rotateY(180deg);
+  z-index:0;
 }
 
 .page.flipped{


### PR DESCRIPTION
## Summary
- Ensure book page images render above the back side by positioning the image absolutely and adjusting z-indexes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2098fa7c4832ebc90d86614ac7b0c