### PR TITLE
feat: refine layout with classical theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,14 +3,21 @@ html,body{
   margin:0;
   padding:0;
   height:100%;
-  background:#f0f0f0;
-  font-family:Arial, Helvetica, sans-serif;
+  background:#fdf8e7;
+  background-image:linear-gradient(rgba(0,0,0,0.03) 1px, transparent 1px),
+                   linear-gradient(90deg, rgba(0,0,0,0.03) 1px, transparent 1px);
+  background-size:20px 20px;
+  font-family:"STKaiti","KaiTi","Songti SC",serif;
+  color:#3d2c1d;
 }
 
 .bookContainer{
   position:relative;
   margin:40px auto;
   perspective:2000px;
+  background:#fff;
+  border:1px solid #d3b17d;
+  box-shadow:0 0 15px rgba(0,0,0,0.2);
 }
 
 .book{
@@ -71,6 +78,18 @@ html,body{
   z-index:5;
 }
 
+button{
+  font-family:"STKaiti","KaiTi","Songti SC",serif;
+  background:#d8caa5;
+  border:1px solid #a67c52;
+  color:#4b3815;
+  border-radius:4px;
+}
+
+button:hover{
+  background:#e6dabc;
+}
+
 /* 翻页细节 */
 .flip-side{backface-visibility:hidden;}
 .flip-hard-left-side{transform-origin:left center;}
@@ -97,7 +116,8 @@ html,body{
   left:0;
   right:0;
   height:40px;
-  background:rgba(255,255,255,0.9);
+  background:rgba(253,248,231,0.9);
+  border-bottom:1px solid #d3b17d;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -111,14 +131,14 @@ html,body{
   display:flex;
   align-items:center;
   justify-content:center;
-  background:rgba(255,255,255,0.8);
+  background:rgba(253,248,231,0.8);
   z-index:100;
 }
 .loadingOuter .spinner{
   width:60px;height:60px;
   border-radius:50%;
-  border:6px solid #ccc;
-  border-top-color:#555;
+  border:6px solid #d8caa5;
+  border-top-color:#8c4b0e;
   animation:rotate 1s linear infinite;
 }
 
@@ -128,15 +148,24 @@ html,body{
   left:0;
   right:0;
   height:40px;
-  background:rgba(255,255,255,0.9);
+  background:rgba(253,248,231,0.9);
+  border-top:1px solid #d3b17d;
   display:flex;
   align-items:center;
   justify-content:center;
   gap:20px;
 }
 .shareBar .share{
+  display:inline-block;
+  padding:6px 10px;
+  background:#d8caa5;
+  border:1px solid #a67c52;
+  border-radius:4px;
   text-decoration:none;
-  color:#555;
+  color:#4b3815;
+}
+.shareBar .share:hover{
+  background:#e6dabc;
 }
 
 /* 悬浮工具栏 */
@@ -149,7 +178,8 @@ html,body{
 }
 .toolbox .toggle{
   width:40px;height:40px;
-  background:#333;
+  background:#8c4b0e;
+  border:1px solid #d3b17d;
   color:#fff;
   display:flex;
   align-items:center;
@@ -162,6 +192,10 @@ html,body{
   display:none;
   flex-direction:column;
   margin-top:10px;
+  background:rgba(253,248,231,0.95);
+  border:1px solid #d3b17d;
+  padding:10px;
+  border-radius:4px;
 }
 .toolbox.open .tools{display:flex;}
 .toolbox .tools button{

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>3D 电子画册</title>
+  <title>古风 3D 电子画册</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- restyle ebook interface with calligraphic fonts and rice-paper background
- apply antique color palette to controls, buttons, and share bar
- update title to match classical theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a27720ec84832eb4f044d8cfa5ce88