### PR TITLE
fix: ensure book container fills height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,8 @@ html,body{
 .book{
   position:relative;
   transform-style:preserve-3d;
+  width:100%;
+  height:100%;
 }
 
 .page{


### PR DESCRIPTION
## Summary
- fix book container not inheriting height which left page images at 0px tall

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2787a59d8832eb0a46db564bf7fa8