### PR TITLE
feat: support cover and two-page spreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FQCalendarWeb
 
-静态 3D 电子画册示例。将图片按 `1.png`, `2.png` … 命名后放入 `content/` 目录中，再在浏览器中打开 `index.html` 体验翻页效果。点击右侧工具栏的 **缩略图** 按钮可以预览所有页面的缩略图并快速跳转。支持键盘方向键翻页，`Esc` 键可关闭缩略图覆盖层。
+静态 3D 电子画册示例。将封面命名为 `0.png`，其余页面按 `1.png`, `2.png` … 命名后放入 `content/` 目录中，再在浏览器中打开 `index.html` 体验翻页效果。封面单页展示，之后每次翻页会同时显示两页（如 `1.png` 与 `2.png`、`3.png` 与 `4.png`）。点击右侧工具栏的 **缩略图** 按钮可以预览内页缩略图并快速跳转。支持键盘方向键翻页，`Esc` 键可关闭缩略图覆盖层。
 
 ## 图片处理工具
 
@@ -22,6 +22,6 @@ python tool/psd_to_png.py assets/psd -o content
 python tool/png_to_thumb.py content
 ```
 
-最终将生成的 `1.png`, `2.png` … 以及对应的 `thumbs/1.webp`, `thumbs/2.webp` … 放在 `content/` 中即可。
+最终将生成的 `0.png`, `1.png`, `2.png` … 以及对应的 `thumbs/1.webp`, `thumbs/2.webp` …（缩略图从 `1.png` 开始，与页面一一对应，`0.png` 作为封面不需要缩略图）放在 `content/` 中即可。
 
 需要依赖 [psd-tools](https://pypi.org/project/psd-tools/) 和 [Pillow](https://pypi.org/project/Pillow/)。

--- a/js/script.js
+++ b/js/script.js
@@ -21,10 +21,12 @@ let dragging = null;
 let dragPage = null;
 let dragStartX = 0;
 let dragMoved = false;
+let totalImages = 0;
 
 async function init(){
   const imgs = await loadImages();
-  if(imgs.length === 0){
+  totalImages = imgs.length;
+  if(totalImages === 0){
     loading.style.display = 'none';
     return;
   }
@@ -32,17 +34,33 @@ async function init(){
   pageHeight = imgs[0].naturalHeight;
   resizeBook();
 
-  imgs.forEach((img, i) => {
+  const leafCount = 1 + Math.ceil((imgs.length - 1) / 2);
+
+  const coverPage = document.createElement('div');
+  coverPage.className = 'page';
+  coverPage.style.zIndex = leafCount;
+  coverPage.appendChild(imgs[0]);
+  book.appendChild(coverPage);
+  pages.push(coverPage);
+
+  for(let i = 1; i < imgs.length; i += 2){
     const page = document.createElement('div');
     page.className = 'page flip-side';
-    page.style.zIndex = imgs.length - i;
-    page.appendChild(img);
-    const back = document.createElement('div');
-    back.className = 'back';
+    page.style.zIndex = leafCount - Math.ceil(i / 2);
+    const front = imgs[i];
+    page.appendChild(front);
+    let back;
+    if(imgs[i + 1]){
+      back = imgs[i + 1];
+      back.classList.add('back');
+    }else{
+      back = document.createElement('div');
+      back.className = 'back';
+    }
     page.appendChild(back);
     book.appendChild(page);
     pages.push(page);
-  });
+  }
   updateUI();
   loading.style.display = 'none';
 }
@@ -59,7 +77,7 @@ function resizeBook(){
 function loadImages(){
   return new Promise(async (resolve) => {
     const imgs = [];
-    let index = 1;
+    let index = 0;
     while(true){
       try{
         const img = await loadImage(`content/${index}.png`);
@@ -136,16 +154,17 @@ function gotoPage(index){
 
 function buildThumbs(){
   thumbsOverlay.innerHTML = '';
-  pages.forEach((_, i) => {
+  for(let i = 1; i < totalImages; i++){
     const img = document.createElement('img');
-    img.src = `content/thumbs/${i + 1}.webp`;
-    img.alt = `缩略图 ${i + 1}`;
+    img.src = `content/thumbs/${i}.webp`;
+    img.alt = `缩略图 ${i}`;
+    const pageIndex = Math.ceil(i / 2);
     img.addEventListener('click', () => {
-      gotoPage(i);
+      gotoPage(pageIndex);
       toggleThumbs();
     });
     thumbsOverlay.appendChild(img);
-  });
+  }
 }
 
 function toggleThumbs(){

--- a/tool/png_to_thumb.py
+++ b/tool/png_to_thumb.py
@@ -13,6 +13,8 @@ def png_to_thumbs(
     dst.mkdir(parents=True, exist_ok=True)
 
     for png_path in src.glob("*.png"):
+        if png_path.stem == "0":
+            continue
         with Image.open(png_path) as img:
             img.thumbnail((size, size))
             out_path = dst / f"{png_path.stem}.webp"


### PR DESCRIPTION
## Summary
- Treat the first image as a standalone cover and pair remaining images into two-page spreads
- Generate thumbnails for every interior page and map each one to its spread
- Document the per-page thumbnail scheme and cover handling

## Testing
- `node --check js/script.js`
- `python -m py_compile tool/png_to_thumb.py tool/png_to_webp.py tool/psd_to_png.py`


------
https://chatgpt.com/codex/tasks/task_e_68a30b047f4c832ea5fb9e4e908caa15