### PR TITLE
Support 0-based page images and auto fit size

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@
 </head>
 
 <body>
-	<script src="./js/jquery.js"></script>
-	<script src="./js/config.js"></script>
-	<script src="./js/main.js"></script>
-	<script src="./js/bookImgData.js"></script>
-	<script src="./js/check.js"></script>
-	<script src="./js/LoadingJS.js"></script>
+        <script src="./js/jquery.js"></script>
+        <script src="./js/config.js"></script>
+        <script src="./js/bookImgData.js"></script>
+        <script src="./js/main.js"></script>
+        <script src="./js/check.js"></script>
+        <script src="./js/LoadingJS.js"></script>
 </body>
 
 </html>

--- a/js/bookImgData.js
+++ b/js/bookImgData.js
@@ -1,27 +1,27 @@
 // 书本目录，如果无ols变量则无目录，ols 变量名勿删，全局共享
-var ols = [
-  {
-    "caption": "测试目录1",
-    "page": "1",
-  },
-  {
-    "caption": "测试目录2",
-    "page": "2",
-  },
-  {
-    "caption": "测试目录3",
-    "page": "3",
-  },
-  {
-    "caption": "测试目录4",
-    "page": "4",
-  },
-];
+var ols = [];
+for (var i = 0; i <= 68; i++) {
+  ols.push({
+    caption: "页面 " + i,
+    page: String(i),
+  });
+}
 
 // 路径配置
-var loadImgpath = "./files/thumb/"
+var loadImgpath = "./files/thumb/";
 
-bookConfig.largePath = loadImgpath    // 大图路径
-bookConfig.normalPath = loadImgpath
-bookConfig.thumbPath = loadImgpath
-bookConfig.totalPageCount = ols.length    // 页面数量
+bookConfig.largePath = loadImgpath; // 大图路径
+bookConfig.normalPath = loadImgpath;
+bookConfig.thumbPath = loadImgpath;
+bookConfig.totalPageCount = ols.length; // 页面数量
+
+// 根据首张图片尺寸自适应页面大小
+(function () {
+  var img = new Image();
+  img.onload = function () {
+    bookConfig.largePageWidth = img.width;
+    bookConfig.largePageHeight = img.height;
+  };
+  img.src = loadImgpath + "0.png";
+})();
+


### PR DESCRIPTION
## Summary
- load book pages from `0.png` through `68.png`
- auto-determine page size from first image and update viewer config
- ensure book configuration is loaded before main script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a34009f248832eb0c70c701c48c766