### PR TITLE
refactor: remove doc preview and speed 3D reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # FQCalendarWeb 项目说明
 
-FQCalendarWeb 提供两种文件展示方案：
-
-- **在线文档预览**：使用外部服务或 `pdf.js` 预览 Word、Excel、PDF 文件。
-- **3D 阅读器**：以翻页杂志的形式浏览图片，可配置页面资源和分享信息。
+FQCalendarWeb 提供 **3D 阅读器**，以翻页杂志的形式浏览图片，可配置页面资源和分享信息。
 
 ## 目录结构
 
@@ -18,7 +15,7 @@ FQCalendarWeb 提供两种文件展示方案：
 
 ### `js/`
 - `config.js`：阅读器核心配置与多语言映射【F:js/config.js†L1-L58】
-- `bookImgData.js`：定义页面数量与图片路径，并根据首图尺寸调整布局【F:js/bookImgData.js†L1-L29】
+- `bookImgData.js`：定义页面数量与图片路径，并在初始化时调整页面布局【F:js/bookImgData.js†L1-L23】
 - `main.js`：翻页逻辑与界面交互脚本（压缩版）
 - `check.js`：提供 SHA 相关函数等校验工具【F:js/check.js†L1-L1】
 - `LoadingJS.js`：注入加载动画的样式和脚本【F:js/LoadingJS.js†L1-L1】
@@ -34,9 +31,4 @@ FQCalendarWeb 提供两种文件展示方案：
 1. 将图片资源放入 `files/thumb/`，按数字命名。
 2. 修改 `bookImgData.js` 中的 `PAGE_START`、`PAGE_END` 或 `loadImgpath` 以匹配资源路径。
 3. 直接打开 `index.html`，即可在浏览器中体验 3D 翻页效果。
-
-如需在线文档预览，可参考以下链接：
-
-- Word/Excel：`https://view.officeapps.live.com/op/view.aspx?src=你的文件地址`
-- PDF：自行部署 `pdf.js`，访问 `pdf/viewer.html?file=你的文件地址`
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 	<meta http-equiv="X-UA-Compatible" content="chrome=1,IE=edge">
 	<meta name="keywords" content="" />
 	<meta name="description" content="" />
-	<title>pdfReader</title>
+        <title>3DReader</title>
 	<link rel="stylesheet" href="./css/style.css" />
 	<link rel="stylesheet" href="./css/player.css" />
 	<link rel="stylesheet" href="./css/phoneTemplate.css" />
@@ -28,12 +28,12 @@
 </head>
 
 <body>
-	<script src="./js/jquery.js"></script>
-	<script src="./js/config.js"></script>
-	<script src="./js/main.js"></script>
-	<script src="./js/bookImgData.js"></script>
-	<script src="./js/check.js"></script>
-	<script src="./js/LoadingJS.js"></script>
+        <script src="./js/jquery.js" defer></script>
+        <script src="./js/config.js" defer></script>
+        <script src="./js/main.js" defer></script>
+        <script src="./js/bookImgData.js" defer></script>
+        <script src="./js/check.js" defer></script>
+        <script src="./js/LoadingJS.js" defer></script>
 </body>
 
 </html>

--- a/js/bookImgData.js
+++ b/js/bookImgData.js
@@ -17,13 +17,7 @@ bookConfig.normalPath = loadImgpath;
 bookConfig.thumbPath = loadImgpath;
 bookConfig.totalPageCount = ols.length;    // 页面数量
 
-// 根据首张图片的尺寸调整页面大小
-var firstImage = new Image();
-firstImage.onload = function () {
-  bookConfig.largePageWidth = this.naturalWidth;
-  bookConfig.largePageHeight = this.naturalHeight;
-  if (typeof onStageResize === 'function') {
-    onStageResize();
-  }
-};
-firstImage.src = loadImgpath + "1.jpg";
+// 使用预设尺寸，避免额外请求首张图片，加快启动速度
+if (typeof onStageResize === 'function') {
+  onStageResize();
+}

--- a/js/config.js
+++ b/js/config.js
@@ -18,7 +18,7 @@ var aliasLanguage = {
 var bookConfig = {
   bookPageStretch: false,
   maxHeightToSmallMode: 360,
-  appName: 'filpPdf',
+  appName: 'Flip3D',
   totalPageCount: 0,
   largePageWidth: 2835,
   largePageHeight: 2480,
@@ -28,7 +28,7 @@ var bookConfig = {
   ToolBarsSettings: "",
   TitleBar: "",
   appLogoLinkURL: "",
-  bookTitle: "pdfReader",
+  bookTitle: "3DReader",
   bookDescription: "",
   ButtonsBar: "",
   ShareButton: "",
@@ -67,13 +67,13 @@ var bookConfig = {
 shareObj = [{
   "name": "QQ空间",
   "url": "http://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=${url}&title=${title}",
-  "logo": "./pdfReader/images/qzone.ico",
+  "logo": "./images/qzone.ico",
   "title": "QQ空间"
 },
 {
   "name": "新浪微博",
   "url": "http://v.t.sina.com.cn/share/share.php?url=${url}&title=${title}",
-  "logo": "./pdfReader/images/sina_weibo.ico",
+  "logo": "./images/sina_weibo.ico",
   "title": "新浪微博"
 }];
 


### PR DESCRIPTION
## Summary
- drop outdated online document preview references so project focuses on the 3D reader
- rename to 3DReader and defer script loading for faster startup
- use preset page dimensions instead of loading the first image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f57dba48832e9e2828749898cd59