### PR TITLE
Hide default mobile overlays for book viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,26 +13,27 @@
 	<meta http-equiv="X-UA-Compatible" content="chrome=1,IE=edge">
         <meta name="keywords" content="" />
         <meta name="description" content="" />
-        <meta name="version" content="1.0.1" />
+        <meta name="version" content="1.0.2" />
         <title>FQ凯丰月历</title>
-        <link rel="stylesheet" href="./css/style.css?v=1.0.1" />
-        <link rel="stylesheet" href="./css/player.css?v=1.0.1" />
-        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.1" />
-        <link rel="stylesheet" href="./css/template.css?v=1.0.1" />
+        <link rel="stylesheet" href="./css/style.css?v=1.0.2" />
+        <link rel="stylesheet" href="./css/player.css?v=1.0.2" />
+        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.2" />
+        <link rel="stylesheet" href="./css/template.css?v=1.0.2" />
 
         <script>
-                var VERSION = "1.0.1";
+                var VERSION = "1.0.2";
         </script>
 </head>
 
 <body>
-        <script src="./js/jquery.js?v=1.0.1"></script>
-        <script src="./js/config.js?v=1.0.1"></script>
-        <script src="./js/main.js?v=1.0.1"></script>
-        <script src="./js/bookImgData.js?v=1.0.1"></script>
-        <script src="./js/check.js?v=1.0.1"></script>
-        <script src="./js/LoadingJS.js?v=1.0.1"></script>
-        <script src="./js/lazyload.js?v=1.0.1"></script>
+        <script src="./js/jquery.js?v=1.0.2"></script>
+        <script src="./js/config.js?v=1.0.2"></script>
+        <script src="./js/main.js?v=1.0.2"></script>
+        <script src="./js/bookImgData.js?v=1.0.2"></script>
+        <script src="./js/check.js?v=1.0.2"></script>
+        <script src="./js/LoadingJS.js?v=1.0.2"></script>
+        <script src="./js/lazyload.js?v=1.0.2"></script>
+        <script src="./js/mobileFix.js?v=1.0.2"></script>
 </body>
 
 </html>

--- a/js/mobileFix.js
+++ b/js/mobileFix.js
@@ -1,0 +1,19 @@
+(function() {
+  function hidePanels() {
+    if (window.frmSearch && frmSearch.visible) {
+      frmSearch.hide();
+    }
+    if (window.frmTableOfContent && frmTableOfContent.visible) {
+      frmTableOfContent.hide();
+    }
+    if (window.thumbnail && thumbnail.visible) {
+      thumbnail.hide();
+    }
+  }
+  if (/Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+    document.addEventListener('DOMContentLoaded', function() {
+      setTimeout(hidePanels, 500);
+    });
+    window.addEventListener('load', hidePanels);
+  }
+})();


### PR DESCRIPTION
## Summary
- Ensure search, directory, and thumbnails panels are hidden on mobile load
- Register mobile-only script to close overlays after viewer initialization
- Bump asset version to 1.0.2 so updated scripts reload on clients

## Testing
- `node --check js/mobileFix.js`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden retrieving package)*

------
https://chatgpt.com/codex/tasks/task_e_68a4302a82c0832e8c4c1a1f5747db2c