### PR TITLE
fix: improve mobile layout

### DIFF
--- a/css/phoneTemplate.css
+++ b/css/phoneTemplate.css
@@ -115,9 +115,16 @@
 		position : absolute;
 		cursor : pointer;
 	}
-	.phoneMoreButton div{
-		width : 25px;
-		height : 25px;
-		margin-left : 20px;
-		margin-top : 7px;
-	}
+        .phoneMoreButton div{
+                width : 25px;
+                height : 25px;
+                margin-left : 20px;
+                margin-top : 7px;
+        }
+
+/* Hide overlay panels on mobile until explicitly opened */
+.search_form.phone,
+.tableofcontent_form.phone,
+#phoneThum {
+        display: none;
+}

--- a/index.html
+++ b/index.html
@@ -13,26 +13,26 @@
 	<meta http-equiv="X-UA-Compatible" content="chrome=1,IE=edge">
         <meta name="keywords" content="" />
         <meta name="description" content="" />
-        <meta name="version" content="1.0.1" />
+        <meta name="version" content="1.0.2" />
         <title>FQ凯丰月历</title>
-        <link rel="stylesheet" href="./css/style.css?v=1.0.1" />
-        <link rel="stylesheet" href="./css/player.css?v=1.0.1" />
-        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.1" />
-        <link rel="stylesheet" href="./css/template.css?v=1.0.1" />
+        <link rel="stylesheet" href="./css/style.css?v=1.0.2" />
+        <link rel="stylesheet" href="./css/player.css?v=1.0.2" />
+        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.2" />
+        <link rel="stylesheet" href="./css/template.css?v=1.0.2" />
 
         <script>
-                var VERSION = "1.0.1";
+                var VERSION = "1.0.2";
         </script>
 </head>
 
 <body>
-        <script src="./js/jquery.js?v=1.0.1"></script>
-        <script src="./js/config.js?v=1.0.1"></script>
-        <script src="./js/main.js?v=1.0.1"></script>
-        <script src="./js/bookImgData.js?v=1.0.1"></script>
-        <script src="./js/check.js?v=1.0.1"></script>
-        <script src="./js/LoadingJS.js?v=1.0.1"></script>
-        <script src="./js/lazyload.js?v=1.0.1"></script>
+        <script src="./js/jquery.js?v=1.0.2"></script>
+        <script src="./js/config.js?v=1.0.2"></script>
+        <script src="./js/main.js?v=1.0.2"></script>
+        <script src="./js/bookImgData.js?v=1.0.2"></script>
+        <script src="./js/check.js?v=1.0.2"></script>
+        <script src="./js/LoadingJS.js?v=1.0.2"></script>
+        <script src="./js/lazyload.js?v=1.0.2"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- hide overlay components on mobile until opened
- bump asset version numbers to 1.0.2 to refresh caches

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a435187ac4832e9627aeeb8eb576ac