### PR TITLE
fix: improve mobile layout

### DIFF
--- a/css/phoneTemplate.css
+++ b/css/phoneTemplate.css
@@ -123,8 +123,13 @@
         }
 
 /* Hide overlay panels on mobile until explicitly opened */
+.bookmark_form.phone,
+.print_form.phone,
 .search_form.phone,
+.setting_form.phone,
+.share_form.phone,
 .tableofcontent_form.phone,
+.about_form.phone,
 #phoneThum {
-        display: none;
+        display: none !important;
 }

--- a/index.html
+++ b/index.html
@@ -13,26 +13,26 @@
 	<meta http-equiv="X-UA-Compatible" content="chrome=1,IE=edge">
         <meta name="keywords" content="" />
         <meta name="description" content="" />
-        <meta name="version" content="1.0.2" />
+        <meta name="version" content="1.0.3" />
         <title>FQ凯丰月历</title>
-        <link rel="stylesheet" href="./css/style.css?v=1.0.2" />
-        <link rel="stylesheet" href="./css/player.css?v=1.0.2" />
-        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.2" />
-        <link rel="stylesheet" href="./css/template.css?v=1.0.2" />
+        <link rel="stylesheet" href="./css/style.css?v=1.0.3" />
+        <link rel="stylesheet" href="./css/player.css?v=1.0.3" />
+        <link rel="stylesheet" href="./css/template.css?v=1.0.3" />
+        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.3" />
 
         <script>
-                var VERSION = "1.0.2";
+                var VERSION = "1.0.3";
         </script>
 </head>
 
 <body>
-        <script src="./js/jquery.js?v=1.0.2"></script>
-        <script src="./js/config.js?v=1.0.2"></script>
-        <script src="./js/main.js?v=1.0.2"></script>
-        <script src="./js/bookImgData.js?v=1.0.2"></script>
-        <script src="./js/check.js?v=1.0.2"></script>
-        <script src="./js/LoadingJS.js?v=1.0.2"></script>
-        <script src="./js/lazyload.js?v=1.0.2"></script>
+        <script src="./js/jquery.js?v=1.0.3"></script>
+        <script src="./js/config.js?v=1.0.3"></script>
+        <script src="./js/main.js?v=1.0.3"></script>
+        <script src="./js/bookImgData.js?v=1.0.3"></script>
+        <script src="./js/check.js?v=1.0.3"></script>
+        <script src="./js/LoadingJS.js?v=1.0.3"></script>
+        <script src="./js/lazyload.js?v=1.0.3"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- hide mobile overlay panels so the album is visible
- load phone styles last and bump assets to version 1.0.3 to bypass cache

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a439358a98832e8aa754fda2851615