### PR TITLE
fix: ensure book displays on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,7 +4,7 @@
 html{width:100%;height:100%;margin:0;padding:0;}
 /* 使用相对定位，避免在移动端由于 fixed 造成的页面不可见问题 */
 body{overflow:hidden!important;width:100%;height:100%;margin:0;padding:0!important;-ms-transform:translate(0);border:0;left:0;top:0;position:relative;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;background:#f8f0e3;background-image:radial-gradient(circle at center,#fdf5e6 0%,#e9d8a6 100%);}
-.tmpContainer{position:fixed;width:100%;height:100%;top: 0;left:0;display:block;overflow:hidden;z-index:-1;}
+.tmpContainer{position:absolute;width:100%;height:100%;top: 0;left:0;display:block;overflow:hidden;z-index:1;}
 .bookContainer{position:absolute;width:100%;height:100%;z-index:2;top:0;left:0;display:block;overflow:hidden;}
 /*//book object*/
 p{margin:0;padding:0;}

--- a/index.html
+++ b/index.html
@@ -13,26 +13,26 @@
 	<meta http-equiv="X-UA-Compatible" content="chrome=1,IE=edge">
         <meta name="keywords" content="" />
         <meta name="description" content="" />
-        <meta name="version" content="1.0.3" />
+        <meta name="version" content="1.0.5" />
         <title>FQ凯丰月历</title>
-        <link rel="stylesheet" href="./css/style.css?v=1.0.3" />
-        <link rel="stylesheet" href="./css/player.css?v=1.0.3" />
-        <link rel="stylesheet" href="./css/template.css?v=1.0.3" />
-        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.3" />
+        <link rel="stylesheet" href="./css/style.css?v=1.0.5" />
+        <link rel="stylesheet" href="./css/player.css?v=1.0.5" />
+        <link rel="stylesheet" href="./css/template.css?v=1.0.5" />
+        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.5" />
 
         <script>
-                var VERSION = "1.0.3";
+                var VERSION = "1.0.5";
         </script>
 </head>
 
 <body>
-        <script src="./js/jquery.js?v=1.0.3"></script>
-        <script src="./js/config.js?v=1.0.3"></script>
-        <script src="./js/main.js?v=1.0.3"></script>
-        <script src="./js/bookImgData.js?v=1.0.3"></script>
-        <script src="./js/check.js?v=1.0.3"></script>
-        <script src="./js/LoadingJS.js?v=1.0.3"></script>
-        <script src="./js/lazyload.js?v=1.0.3"></script>
+        <script src="./js/jquery.js?v=1.0.5"></script>
+        <script src="./js/config.js?v=1.0.5"></script>
+        <script src="./js/main.js?v=1.0.5"></script>
+        <script src="./js/bookImgData.js?v=1.0.5"></script>
+        <script src="./js/check.js?v=1.0.5"></script>
+        <script src="./js/LoadingJS.js?v=1.0.5"></script>
+        <script src="./js/lazyload.js?v=1.0.5"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- raise temp container layer so flipbook stays visible on phones
- bump asset version to 1.0.5 to avoid cached pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43dbc6b54832e83d53c886ef53233