### PR TITLE
fix: ensure book data loads before main script

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,9 @@
 <body>
         <script src="./js/jquery.js?v=1.0.5"></script>
         <script src="./js/config.js?v=1.0.5"></script>
-        <script src="./js/main.js?v=1.0.5"></script>
+        <!-- 提前加载页面资源配置，确保主脚本初始化时已获取到图片路径与页数 -->
         <script src="./js/bookImgData.js?v=1.0.5"></script>
+        <script src="./js/main.js?v=1.0.5"></script>
         <script src="./js/check.js?v=1.0.5"></script>
         <script src="./js/LoadingJS.js?v=1.0.5"></script>
         <script src="./js/lazyload.js?v=1.0.5"></script>


### PR DESCRIPTION
## Summary
- load `bookImgData.js` before `main.js` so page paths and counts are ready when the viewer initializes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a45b866b28832ebac9d16ba076ecfd