### PR TITLE
fix: ensure flipbook pages load before initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ FQCalendarWeb 提供 **FQ凯丰月历**，以翻页杂志的形式浏览图片�
 ## 使用说明
 1. 将图片资源放入 `files/thumb/`，按数字命名。
 2. 修改 `bookImgData.js` 中的 `PAGE_START`、`PAGE_END` 或 `loadImgpath` 以匹配资源路径。
-3. 更新 `index.html` 中的版本号可避免浏览器缓存旧资源。
-4. 直接打开 `index.html`，即可在浏览器中体验 3D 翻页效果。
+3. 确保在 `index.html` 中先加载 `bookImgData.js`，再加载 `main.js`，以便在翻页组件初始化前提供页面数据。
+4. 更新 `index.html` 中的版本号可避免浏览器缓存旧资源。
+5. 直接打开 `index.html`，即可在浏览器中体验 3D 翻页效果。
 
 ### 移动端兼容
 为确保在 iOS 等移动设备上能够正常加载电子杂志，`index.html` 中的脚本不再使用 `defer` 属性，以保证按顺序同步加载。

--- a/index.html
+++ b/index.html
@@ -13,26 +13,26 @@
 	<meta http-equiv="X-UA-Compatible" content="chrome=1,IE=edge">
         <meta name="keywords" content="" />
         <meta name="description" content="" />
-        <meta name="version" content="1.0.5" />
+        <meta name="version" content="1.0.6" />
         <title>FQ凯丰月历</title>
-        <link rel="stylesheet" href="./css/style.css?v=1.0.5" />
-        <link rel="stylesheet" href="./css/player.css?v=1.0.5" />
-        <link rel="stylesheet" href="./css/template.css?v=1.0.5" />
-        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.5" />
+        <link rel="stylesheet" href="./css/style.css?v=1.0.6" />
+        <link rel="stylesheet" href="./css/player.css?v=1.0.6" />
+        <link rel="stylesheet" href="./css/template.css?v=1.0.6" />
+        <link rel="stylesheet" href="./css/phoneTemplate.css?v=1.0.6" />
 
         <script>
-                var VERSION = "1.0.5";
+                var VERSION = "1.0.6";
         </script>
 </head>
 
 <body>
-        <script src="./js/jquery.js?v=1.0.5"></script>
-        <script src="./js/config.js?v=1.0.5"></script>
-        <script src="./js/main.js?v=1.0.5"></script>
-        <script src="./js/bookImgData.js?v=1.0.5"></script>
-        <script src="./js/check.js?v=1.0.5"></script>
-        <script src="./js/LoadingJS.js?v=1.0.5"></script>
-        <script src="./js/lazyload.js?v=1.0.5"></script>
+        <script src="./js/jquery.js?v=1.0.6"></script>
+        <script src="./js/config.js?v=1.0.6"></script>
+        <script src="./js/bookImgData.js?v=1.0.6"></script>
+        <script src="./js/main.js?v=1.0.6"></script>
+        <script src="./js/check.js?v=1.0.6"></script>
+        <script src="./js/LoadingJS.js?v=1.0.6"></script>
+        <script src="./js/lazyload.js?v=1.0.6"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- load `bookImgData.js` before `main.js` so page data is ready when the flipbook initializes
- document script order and bump asset versions to 1.0.6 to invalidate caches

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a45b866b28832ebac9d16ba076ecfd